### PR TITLE
Potential fix for Issue #100

### DIFF
--- a/ATT-Classic.lua
+++ b/ATT-Classic.lua
@@ -1823,8 +1823,8 @@ local function GetCachedSearchResults(search, method, paramA, paramB, ...)
 						tinsert(info, { left = "Used in Recipes:" });
 						if #entries < 25 then
 							table.sort(entries, function(a, b)
-								if a.group.name then
-									if b.group.name then
+								if a and a.group.name then
+									if b and b.group.name then
 										return a.group.name <= b.group.name;
 									end
 									return true;


### PR DESCRIPTION
https://github.com/DFortun81/ATT-Classic/issues/100

Was unable to reproduce it locally, but it seems to be a missing nil check. The issue was regarding the `b` operand but I also added the same sanity check to the `a` operand to ensure a safe comparison.